### PR TITLE
Card validation fully complete

### DIFF
--- a/SwiftValidator/Rules/CardExpiryRule.swift
+++ b/SwiftValidator/Rules/CardExpiryRule.swift
@@ -1,0 +1,61 @@
+//
+//  CardExpiryRule.swift
+//  SwiftValidator
+//
+//  Created by Sprinthub on 13/03/2019.
+//  Copyright © 2019 jpotts18. All rights reserved.
+//
+
+import Foundation
+
+
+
+/**
+ `CardExpiryRule` is a subclass of `Rule` that defines how a credit/debit's card number field is validated
+ */
+public class CardExpiryRule: Rule {
+    /// Error message to be displayed if validation fails.
+    private var message : String
+    /**
+     Initializes `CardNumberRule` object with error message. Used to validate a card's expiry month.
+     
+     - parameter message: String of error message.
+     - returns: An initialized `CardNumberRule` object, or nil if an object could not be created for some reason that would not result in an exception.
+     */
+    public init(message : String = "Card expiry date is invalid"){
+        self.message = message
+    }
+    
+    /**
+     Validates a field.
+     
+     - parameter value: String to check for validation.
+     - returns: Boolean value. True on successful validation, otherwise False on failed Validation.
+     */
+    public func validate(_ value: String) -> Bool {
+        let date = value.replacingOccurrences(of: "/", with: "")
+        let Index = date.index(date.startIndex, offsetBy: 2)
+        //let yearIndex = date.index(date.endIndex, offsetBy: -2)
+        let Month = Int(date[..<Index])
+        let Year = Int(date[Index...])
+        
+        ///Holds the current year
+        let thisYear = String(NSCalendar.current.component(Calendar.Component.year, from: Date()))
+        let thisYearLast2 = thisYear.index(thisYear.startIndex, offsetBy: 2)
+        let thisYearTwoDigits = Int(thisYear[thisYearLast2...])!
+        
+        
+        return Month! < 12 && Year! >= thisYearTwoDigits
+        
+    }
+    
+    /**
+     Used to display error message when validation fails.
+     
+     - returns: String of error message.
+     */
+    public func errorMessage() -> String {
+        return message
+    }
+    
+}

--- a/SwiftValidator/Rules/CardExpiryRule.swift
+++ b/SwiftValidator/Rules/CardExpiryRule.swift
@@ -2,7 +2,7 @@
 //  CardExpiryRule.swift
 //  SwiftValidator
 //
-//  Created by Sprinthub on 13/03/2019.
+//  Created by Mark Boleigha on 13/03/2019.
 //  Copyright © 2019 jpotts18. All rights reserved.
 //
 
@@ -17,10 +17,10 @@ public class CardExpiryRule: Rule {
     /// Error message to be displayed if validation fails.
     private var message : String
     /**
-     Initializes `CardNumberRule` object with error message. Used to validate a card's expiry month.
+     Initializes `CardExpiryRule` object with error message. Used to validate a card's expiry year.
      
      - parameter message: String of error message.
-     - returns: An initialized `CardNumberRule` object, or nil if an object could not be created for some reason that would not result in an exception.
+     - returns: An initialized `CardExpiryRule` object, or nil if an object could not be created for some reason that would not result in an exception.
      */
     public init(message : String = "Card expiry date is invalid"){
         self.message = message
@@ -29,7 +29,7 @@ public class CardExpiryRule: Rule {
     /**
      Validates a field.
      
-     - parameter value: String to check for validation.
+     - parameter value: String to check for validation. must be a card expiry date in MM/YY format
      - returns: Boolean value. True on successful validation, otherwise False on failed Validation.
      */
     public func validate(_ value: String) -> Bool {

--- a/SwiftValidator/Rules/CardNumberRule.swift
+++ b/SwiftValidator/Rules/CardNumberRule.swift
@@ -34,15 +34,6 @@ public class CardNumberRule: Rule {
         guard CardState(fromNumber: cardNoFull) != .invalid else {
             return false
         }
-//        let cardState = CardState(fromNumber: cardNoFull)
-//        switch cardState {
-//            case .identified(let cardType):
-//                print(cardType)
-//            case .indeterminate:
-//                print("undefined")
-//            case .invalid:
-//                print("invalid")
-//        }
         
         return true
         

--- a/SwiftValidatorTests/SwiftValidatorTests.swift
+++ b/SwiftValidatorTests/SwiftValidatorTests.swift
@@ -34,7 +34,7 @@ class SwiftValidatorTests: XCTestCase {
     let VALID_CARD_EXPIRY_MONTH = "10"
     let INVALID_CARD_EXPIRY_MONTH = "13"
     
-    let VALID_CARD_EXPIRY_YEAR = "2018"
+    let VALID_CARD_EXPIRY_YEAR = "2020"
     let INVALID_CARD_EXPIRY_YEAR = "2016"
     
     let LEN_3 = "hey"
@@ -95,6 +95,10 @@ class SwiftValidatorTests: XCTestCase {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
         super.tearDown()
     }
+    
+    //CARD EXPIRY VALIDATION VALUES
+    let VALID_DATE = "10/29"
+    let INVALID_DATE = "10/12"
     
     //MARK: CARD NUMBER VALIDATION
 
@@ -185,6 +189,19 @@ class SwiftValidatorTests: XCTestCase {
     }
     
     func testCardExpiryYearmessage() {
+        XCTAssertNotNil(CardExpiryYearRule().errorMessage())
+    }
+    
+    // MARK: CARD EXPIRY DATE
+    func testValidCardExpiryDateFull(){
+        XCTAssertTrue(CardExpiryRule().validate(VALID_DATE), "Valid card expiry date should retun true")
+    }
+    
+    func testInvalidCardExpiryDateFull(){
+        XCTAssertFalse(CardExpiryRule().validate(INVALID_DATE), "Invalid card expiry date should return false")
+    }
+    
+    func testInvalidCardExpiryDateFullMessage(){
         XCTAssertNotNil(CardExpiryYearRule().errorMessage())
     }
     

--- a/Validator.xcodeproj/project.pbxproj
+++ b/Validator.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		256576A72232DFD900C8369F /* CardNumberRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 256576A62232DFD900C8369F /* CardNumberRule.swift */; };
 		256576AA2232E01500C8369F /* CardParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 256576A92232E01500C8369F /* CardParser.swift */; };
+		25FB0A2A22395AFA00373197 /* CardExpiryRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25FB0A2922395AFA00373197 /* CardExpiryRule.swift */; };
 		62C1821D1C6312F5003788E7 /* ExactLengthRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62C1821C1C6312F5003788E7 /* ExactLengthRule.swift */; };
 		62D1AE1D1A1E6D4400E4DFF8 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62D1AE1C1A1E6D4400E4DFF8 /* AppDelegate.swift */; };
 		62D1AE221A1E6D4400E4DFF8 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 62D1AE201A1E6D4400E4DFF8 /* Main.storyboard */; };
@@ -96,6 +97,7 @@
 /* Begin PBXFileReference section */
 		256576A62232DFD900C8369F /* CardNumberRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardNumberRule.swift; sourceTree = "<group>"; };
 		256576A92232E01500C8369F /* CardParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardParser.swift; sourceTree = "<group>"; };
+		25FB0A2922395AFA00373197 /* CardExpiryRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardExpiryRule.swift; sourceTree = "<group>"; };
 		62C1821C1C6312F5003788E7 /* ExactLengthRule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExactLengthRule.swift; sourceTree = "<group>"; };
 		62D1AE171A1E6D4400E4DFF8 /* Validator.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Validator.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		62D1AE1B1A1E6D4400E4DFF8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -300,6 +302,7 @@
 				FB465CEB1B9889EA00398388 /* RegexRule.swift */,
 				FB465CEC1B9889EA00398388 /* RequiredRule.swift */,
 				FB465CED1B9889EA00398388 /* Rule.swift */,
+				25FB0A2922395AFA00373197 /* CardExpiryRule.swift */,
 				FB465CEE1B9889EA00398388 /* ValidationRule.swift */,
 				FB465CEF1B9889EA00398388 /* ZipCodeRule.swift */,
 				62C1821C1C6312F5003788E7 /* ExactLengthRule.swift */,
@@ -538,6 +541,7 @@
 				256576A72232DFD900C8369F /* CardNumberRule.swift in Sources */,
 				7CC1E4D71C637F6E00AF013C /* ISBNRule.swift in Sources */,
 				FB465D001B9889EA00398388 /* ValidationError.swift in Sources */,
+				25FB0A2A22395AFA00373197 /* CardExpiryRule.swift in Sources */,
 				FB465CFC1B9889EA00398388 /* RequiredRule.swift in Sources */,
 				FB465CFB1B9889EA00398388 /* RegexRule.swift in Sources */,
 				7CC1E4CF1C636B4500AF013C /* AlphaRule.swift in Sources */,


### PR DESCRIPTION
Card expiry date can be validated without splitting month and year like before. simply enter card expiry date in MM/YY format and it will be validated correctly